### PR TITLE
Notify stakeholders when termination marked inactive

### DIFF
--- a/app/Notifications/TerminationDeletedNotification.php
+++ b/app/Notifications/TerminationDeletedNotification.php
@@ -47,9 +47,12 @@ class TerminationDeletedNotification extends Notification
    */
   public function toMail($notifiable)
   {
+    $subject = $this->myData['mail_subject'] ?? 'Mitarbeiter aktualisiert';
+    $line = $this->myData['mail_line'] ?? ($this->myData['name'] . ' aus ' . $this->myData['location'] . ' wurde aktualisiert.');
+
     return (new MailMessage)
-      ->subject('Mitarbeiter gelöscht')
-      ->line($this->myData['name'] . ' aus ' . $this->myData['location'] . ' wurde gelöscht.');
+      ->subject($subject)
+      ->line($line);
   }
 
   /**
@@ -66,6 +69,7 @@ class TerminationDeletedNotification extends Notification
       'name' => $this->myData['name'],
       'location' => $this->myData['location'],
       'occupation' => $this->myData['occupation'],
+      'status' => $this->myData['status'] ?? null,
     ];
   }
 


### PR DESCRIPTION
## Summary
- send termination notifications when an employee is marked inactive
- centralize notification payload and recipient handling for termination status changes
- allow the termination notification template to use custom subjects and messaging

## Testing
- phpunit *(fails: command not found)*
- ./vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dd17183ef48329a0696b16bf4914a0