### PR TITLE
Include tomorrow-starting email forwards in unassigned header count

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -955,6 +955,10 @@ public function userticketshistory()
   private function getActiveForwardingCountForHeader()
   {
     $today = Carbon::today();
+    $nextCheckDate = $today->isFriday()
+      ? $today->copy()->next(Carbon::MONDAY)
+      : $today->copy()->addDay();
+
     $activeTodayIds = Ticket::where('problem_type', 'Email Weiterleitung')
       ->whereNotNull('forward_required_at')
       ->whereNotNull('forward_to_at')
@@ -962,19 +966,14 @@ public function userticketshistory()
       ->whereDate('forward_to_at', '>=', $today)
       ->pluck('id');
 
-    if (!$today->isFriday()) {
-      return $activeTodayIds->count();
-    }
-
-    $nextMonday = $today->copy()->next(Carbon::MONDAY);
-    $activeMondayIds = Ticket::where('problem_type', 'Email Weiterleitung')
+    $activeUpcomingIds = Ticket::where('problem_type', 'Email Weiterleitung')
       ->whereNotNull('forward_required_at')
       ->whereNotNull('forward_to_at')
-      ->whereDate('forward_required_at', '<=', $nextMonday)
-      ->whereDate('forward_to_at', '>=', $nextMonday)
+      ->whereDate('forward_required_at', '<=', $nextCheckDate)
+      ->whereDate('forward_to_at', '>=', $nextCheckDate)
       ->pluck('id');
 
-    return $activeTodayIds->merge($activeMondayIds)->unique()->count();
+    return $activeTodayIds->merge($activeUpcomingIds)->unique()->count();
   }
 
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -882,6 +882,7 @@ public function userticketshistory()
       $myTicketsCount = Ticket::where('submitter', $user->id)->orWhere('assignedTo', $user->id)->count();
     }
 
+    $activeForwardingCount = $this->getActiveForwardingCountForHeader();
     $cityTicketCounts = $this->getCityTicketCounts();
 
     return view('tickets.admins.open', compact(
@@ -892,7 +893,8 @@ public function userticketshistory()
       'UnassignedTicketsCount',
       'myTicketsCount',
       'ticketCounts',
-      'cityTicketCounts'
+      'cityTicketCounts',
+      'activeForwardingCount'
     ));
   }
   

--- a/resources/views/tickets/admins/tables/tickettable.blade.php
+++ b/resources/views/tickets/admins/tables/tickettable.blade.php
@@ -171,7 +171,7 @@
               Anzahl Erledigter Tickets: {{@$done}}
               @endif
             </h3>
-            @if (URL::current() == route('ticket.unassigned'))
+            @if (URL::current() == route('ticket.unassigned') || URL::current() == route('ticket.opentickets'))
             <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-primary mt-2 mt-md-0">
               Aktiv {{ (int)($activeForwardingCount ?? 0) }} Weiterleitungen
             </a>

--- a/resources/views/tickets/admins/tables/tickettable.blade.php
+++ b/resources/views/tickets/admins/tables/tickettable.blade.php
@@ -58,6 +58,26 @@
       margin-top: 10px;
     }
   }
+
+  .forwarding-count {
+    font-weight: 700;
+  }
+
+  .forwarding-count.is-alert {
+    display: inline-block;
+    animation: forwardingPulse 1s infinite;
+  }
+
+  @keyframes forwardingPulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: .25;
+    }
+  }
 </style>
 
 @section('content')
@@ -173,7 +193,11 @@
             </h3>
             @if (URL::current() == route('ticket.unassigned') || URL::current() == route('ticket.opentickets'))
             <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-primary mt-2 mt-md-0">
-              Aktiv {{ (int)($activeForwardingCount ?? 0) }} Weiterleitungen
+              Aktiv
+              <span class="forwarding-count {{ (int)($activeForwardingCount ?? 0) > 0 ? 'is-alert' : '' }}">
+                {{ (int)($activeForwardingCount ?? 0) }}
+              </span>
+              Weiterleitungen
             </a>
             @endif
           </div>


### PR DESCRIPTION
### Motivation
- Email-forwarding tickets with `forward_required_at` set to tomorrow were not reflected in the unassigned page header, causing the "ab morgen" cases to be invisible. 
- The count should still keep the Friday special-case (check Monday) while also showing tickets becoming active on the next check date.

### Description
- Updated `getActiveForwardingCountForHeader()` in `app/Http/Controllers/TicketController.php` to include upcoming forwards. 
- Compute `nextCheckDate` as next Monday when today is Friday, otherwise as tomorrow (`addDay()`). 
- Query both tickets active today and tickets active on `nextCheckDate`, merge their IDs and return the unique count.

### Testing
- Ran `php -l app/Http/Controllers/TicketController.php` and there were no syntax errors. 
- No additional automated test suite was executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0f792be88329b214ca7940167239)