### PR TITLE
Add tracking and removal workflow for email forwardings

### DIFF
--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -24,7 +24,7 @@ class LicenseController extends Controller
       $month = Carbon::now()->addDays(30);
       $week = Carbon::now()->addDays(7);
       $terminations = Termination::orderBy('exit', 'ASC')->get();
-      $emailForwardingTickets = Ticket::with(['subUser', 'forwardOnUser', 'forwardFromUser'])
+      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser'])
         ->where('problem_type', 'Email Weiterleitung')
         ->orderBy('forward_required_at', 'asc')
         ->orderByDesc('created_at')
@@ -34,11 +34,10 @@ class LicenseController extends Controller
           return false;
         }
 
-        $now = Carbon::now();
-        return Carbon::parse($ticket->forward_to_at)->endOfDay()->gte($now);
+        return empty($ticket->forward_removed_at);
       })->values();
-      $historyEmailForwardingTickets = $emailForwardingTickets->reject(function ($ticket) use ($activeEmailForwardingTickets) {
-        return $activeEmailForwardingTickets->contains('id', $ticket->id);
+      $historyEmailForwardingTickets = $emailForwardingTickets->filter(function ($ticket) {
+        return !empty($ticket->forward_removed_at);
       })->values();
 
       return view('wilkommen', compact(

--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -24,7 +24,7 @@ class LicenseController extends Controller
       $month = Carbon::now()->addDays(30);
       $week = Carbon::now()->addDays(7);
       $terminations = Termination::orderBy('exit', 'ASC')->get();
-      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser'])
+      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser', 'user'])
         ->where('problem_type', 'Email Weiterleitung')
         ->orderBy('forward_required_at', 'asc')
         ->orderByDesc('created_at')

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -57,7 +57,7 @@ class TicketController extends Controller
       $month = Carbon::now()->addDays(30);
       $week = Carbon::now()->addDays(7);
       $terminations = Termination::orderBy('exit', 'ASC')->get();
-      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser'])
+      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser', 'user'])
         ->where('problem_type', 'Email Weiterleitung')
         ->orderBy('forward_required_at', 'asc')
         ->orderByDesc('created_at')

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -57,7 +57,7 @@ class TicketController extends Controller
       $month = Carbon::now()->addDays(30);
       $week = Carbon::now()->addDays(7);
       $terminations = Termination::orderBy('exit', 'ASC')->get();
-      $emailForwardingTickets = Ticket::with(['subUser', 'forwardOnUser', 'forwardFromUser'])
+      $emailForwardingTickets = Ticket::withTrashed()->with(['subUser', 'forwardOnUser', 'forwardFromUser', 'forwardRemovedByUser'])
         ->where('problem_type', 'Email Weiterleitung')
         ->orderBy('forward_required_at', 'asc')
         ->orderByDesc('created_at')
@@ -67,11 +67,10 @@ class TicketController extends Controller
           return false;
         }
 
-        $now = Carbon::now();
-        return Carbon::parse($ticket->forward_to_at)->endOfDay()->gte($now);
+        return empty($ticket->forward_removed_at);
       })->values();
-      $historyEmailForwardingTickets = $emailForwardingTickets->reject(function ($ticket) use ($activeEmailForwardingTickets) {
-        return $activeEmailForwardingTickets->contains('id', $ticket->id);
+      $historyEmailForwardingTickets = $emailForwardingTickets->filter(function ($ticket) {
+        return !empty($ticket->forward_removed_at);
       })->values();
 
       return view('wilkommen', compact(
@@ -956,26 +955,31 @@ public function userticketshistory()
 
   private function getActiveForwardingCountForHeader()
   {
-    $today = Carbon::today();
-    $nextCheckDate = $today->isFriday()
-      ? $today->copy()->next(Carbon::MONDAY)
-      : $today->copy()->addDay();
-
-    $activeTodayIds = Ticket::where('problem_type', 'Email Weiterleitung')
+    return Ticket::withTrashed()->where('problem_type', 'Email Weiterleitung')
       ->whereNotNull('forward_required_at')
       ->whereNotNull('forward_to_at')
-      ->whereDate('forward_required_at', '<=', $today)
-      ->whereDate('forward_to_at', '>=', $today)
-      ->pluck('id');
+      ->whereNull('forward_removed_at')
+      ->count();
+  }
 
-    $activeUpcomingIds = Ticket::where('problem_type', 'Email Weiterleitung')
-      ->whereNotNull('forward_required_at')
-      ->whereNotNull('forward_to_at')
-      ->whereDate('forward_required_at', '<=', $nextCheckDate)
-      ->whereDate('forward_to_at', '>=', $nextCheckDate)
-      ->pluck('id');
+  public function markForwardingRemoved($ticketId)
+  {
+    $user = Auth::user();
+    if (!$user || !$user->hasAnyRole(['Super_Admin', 'HR'])) {
+      abort(403, 'Unauthorized action.');
+    }
 
-    return $activeTodayIds->merge($activeUpcomingIds)->unique()->count();
+    $ticket = Ticket::withTrashed()->findOrFail($ticketId);
+
+    if ($ticket->problem_type !== 'Email Weiterleitung') {
+      return redirect()->back()->withErrors(['forwarding' => 'Nur E-Mail-Weiterleitungen können als aufgehoben markiert werden.']);
+    }
+
+    $ticket->forward_removed_at = Carbon::now();
+    $ticket->forward_removed_by = $user->id;
+    $ticket->save();
+
+    return redirect()->back()->with('status', 'Weiterleitung wurde als aufgehoben markiert.');
   }
 
 

--- a/app/Ticket.php
+++ b/app/Ticket.php
@@ -17,6 +17,7 @@ class Ticket extends Model
     'participant_required_at',
     'forward_required_at',
     'forward_to_at',
+    'forward_removed_at',
     'employee_required_at',
     'employee_finish_at'
   ];
@@ -96,6 +97,12 @@ class Ticket extends Model
   {
     return $this->belongsTo('App\User', 'forward_from', 'id')->withTrashed();
   }
+
+  public function forwardRemovedByUser()
+  {
+    return $this->belongsTo('App\User', 'forward_removed_by', 'id')->withTrashed();
+  }
+
   public function specialComments()
   {
     return $this->hasMany(TicketSpecialComment::class)->latest('created_at');

--- a/database/migrations/2026_04_02_150000_add_forward_removed_tracking_to_tickets_table.php
+++ b/database/migrations/2026_04_02_150000_add_forward_removed_tracking_to_tickets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForwardRemovedTrackingToTicketsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dateTime('forward_removed_at')->nullable()->after('forward_to_at');
+            $table->unsignedBigInteger('forward_removed_by')->nullable()->after('forward_removed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropColumn(['forward_removed_at', 'forward_removed_by']);
+        });
+    }
+}

--- a/resources/views/wilkommen.blade.php
+++ b/resources/views/wilkommen.blade.php
@@ -180,6 +180,16 @@
                                           <td>{{ optional($forwardingTicket->subUser)->name }}, {{ optional($forwardingTicket->subUser)->vorname }}</td>
                                           <td>{{ optional($forwardingTicket->created_at)->format('d.m.Y H:i') }}</td>
                                           <td>
+                                            <div class="small text-muted mb-1">
+                                              <div><strong>Zugewiesen:</strong>
+                                                @if($forwardingTicket->user)
+                                                  {{ $forwardingTicket->user->name }}, {{ $forwardingTicket->user->vorname }}
+                                                @else
+                                                  -
+                                                @endif
+                                              </div>
+                                              <div><strong>Erledigt von:</strong> {{ $forwardingTicket->done_by ?? '-' }}</div>
+                                            </div>
                                             <form method="POST" action="{{ route('ticket.forwarding_removed', $forwardingTicket->id) }}">
                                               @csrf
                                               <button type="submit" class="btn btn-sm btn-success">

--- a/resources/views/wilkommen.blade.php
+++ b/resources/views/wilkommen.blade.php
@@ -128,6 +128,11 @@
                                     </button>
                                   </div>
                                 </div>
+                                @if (session('status'))
+                                <div class="px-3 pt-2">
+                                  <div class="alert alert-success mb-0">{{ session('status') }}</div>
+                                </div>
+                                @endif
                                 <div class="card-body p-0">
                                   <div class="mailbox-messages p-2">
                                     <table id="forwarding_active_table" class="display nowrap table-sm" style="width:100%">
@@ -137,12 +142,17 @@
                                           <th>An</th>
                                           <th>Von Datum</th>
                                           <th>Bis Datum</th>
+                                          <th>Status</th>
                                           <th>Erstellt von</th>
                                           <th>Eingereicht am</th>
+                                          <th>Aktion</th>
                                         </tr>
                                       </thead>
                                       <tbody>
                                         @foreach(($activeEmailForwardingTickets ?? collect()) as $forwardingTicket)
+                                        @php
+                                          $isOverdue = !empty($forwardingTicket->forward_to_at) && optional($forwardingTicket->forward_to_at)->endOfDay()->lt(\Carbon\Carbon::now());
+                                        @endphp
                                         <tr>
                                           <td>
                                             @if($forwardingTicket->forwardFromUser)
@@ -160,8 +170,23 @@
                                           </td>
                                           <td>{{ optional($forwardingTicket->forward_required_at)->format('d.m.Y') }}</td>
                                           <td>{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
+                                          <td>
+                                            @if($isOverdue)
+                                              <span class="badge badge-danger">Überfällig</span>
+                                            @else
+                                              <span class="badge badge-warning">Aktiv</span>
+                                            @endif
+                                          </td>
                                           <td>{{ optional($forwardingTicket->subUser)->name }}, {{ optional($forwardingTicket->subUser)->vorname }}</td>
                                           <td>{{ optional($forwardingTicket->created_at)->format('d.m.Y H:i') }}</td>
+                                          <td>
+                                            <form method="POST" action="{{ route('ticket.forwarding_removed', $forwardingTicket->id) }}">
+                                              @csrf
+                                              <button type="submit" class="btn btn-sm btn-success">
+                                                Als entfernt markieren
+                                              </button>
+                                            </form>
+                                          </td>
                                         </tr>
                                         @endforeach
                                       </tbody>
@@ -183,8 +208,11 @@
                                           <th>An</th>
                                           <th>Von Datum</th>
                                           <th>Bis Datum</th>
+                                          <th>Status</th>
                                           <th>Erstellt von</th>
                                           <th>Eingereicht am</th>
+                                          <th>Entfernt am</th>
+                                          <th>Entfernt von</th>
                                         </tr>
                                       </thead>
                                       <tbody>
@@ -206,8 +234,17 @@
                                           </td>
                                           <td>{{ optional($forwardingTicket->forward_required_at)->format('d.m.Y') }}</td>
                                           <td>{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
+                                          <td><span class="badge badge-secondary">Entfernt</span></td>
                                           <td>{{ optional($forwardingTicket->subUser)->name }}, {{ optional($forwardingTicket->subUser)->vorname }}</td>
                                           <td>{{ optional($forwardingTicket->created_at)->format('d.m.Y H:i') }}</td>
+                                          <td>{{ optional($forwardingTicket->forward_removed_at)->format('d.m.Y H:i') }}</td>
+                                          <td>
+                                            @if($forwardingTicket->forwardRemovedByUser)
+                                              {{ $forwardingTicket->forwardRemovedByUser->name }}, {{ $forwardingTicket->forwardRemovedByUser->vorname }}
+                                            @else
+                                              -
+                                            @endif
+                                          </td>
                                         </tr>
                                         @endforeach
                                       </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -402,6 +402,7 @@ Route::post('/ticket.restore/{myTicket}', 'TicketController@restore')->name('tic
 Route::post('/ticket/assignTo', 'TicketController@assignedTo')->name('ticket.assignedTo');
 Route::post('/ticket/priority', 'TicketController@ticketPriority')->name('ticket.ticketPriority');
 Route::post('/ticket/status', 'TicketController@ticketStatus')->name('ticket.ticketStatus');
+Route::post('/ticket/{ticketId}/forwarding-removed', 'TicketController@markForwardingRemoved')->name('ticket.forwarding_removed');
 Route::post('/ticket/admin_notes', 'TicketController@admin_notes')->name('ticket.admin_notes');
 Route::post('/ticket/employee_username', 'TicketController@employee_username')->name('ticket.employee_username'); //! employee username ajax 
 Route::post('/ticket/employee_password', 'TicketController@employee_password')->name('ticket.employee_password'); //! employee password ajax 


### PR DESCRIPTION
### Motivation
- Provide a way to mark E-Mail-Weiterleitung (email forwarding) tickets as removed and surface that state in the UI and counts.
- Persist who and when a forwarding was removed so history can be audited.

### Description
- Added a migration `2026_04_02_150000_add_forward_removed_tracking_to_tickets_table.php` to add `forward_removed_at` and `forward_removed_by` columns to the `tickets` table.
- Extended the `Ticket` model to include `forward_removed_at` in the `$dates` array and added the `forwardRemovedByUser()` relationship.
- Updated controller logic in `TicketController` and `LicenseController` to load forwarding tickets with `withTrashed()` and to split active vs history by `forward_removed_at` (active = null, history = not null), and adjusted `getActiveForwardingCountForHeader()` to count only not-removed forwardings.
- Implemented `markForwardingRemoved($ticketId)` in `TicketController` to set `forward_removed_at` and `forward_removed_by` with role-based authorization for `Super_Admin` and `HR` users and return a status flash message.
- Added a POST route `ticket.forwarding_removed` (`/ticket/{ticketId}/forwarding-removed`) to trigger the removal action.
- Updated `wilkommen.blade.php` to show status badges, an action button to mark forwardings as removed for active items, and to display removal metadata in the history view, plus flash message display.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce226d4ad88329a7a30d2ec0bc9e62)