### PR TITLE
Normalize participant location matching to Place records and grant Teilnehmer_Info sidebar access

### DIFF
--- a/app/Http/Controllers/ParticipantTicketTableController.php
+++ b/app/Http/Controllers/ParticipantTicketTableController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Ticket;
+use App\Place;
 use Illuminate\Http\Request;
 use App\ParticipantTicketTable;
 use Illuminate\Support\Facades\Redirect;
@@ -30,15 +31,32 @@ public function index()
     } else {
         if ($user->ort === 'Berlin') {
             if ($user->straße === 'Prenzlauer Promenade 28') {
-                $participantsQuery->where('location', 'Berlin-PP');
+                $targetLocation = 'Berlin-PP';
             } elseif ($user->straße === 'Trachenbergring 93') {
-                $participantsQuery->where('location', 'Berlin-TBR');
+                $targetLocation = 'Berlin-TBR';
             } else {
-                $participantsQuery->where('location', 'Berlin');
+                $targetLocation = 'Berlin';
             }
         } else {
-            $participantsQuery->where('location', $user->ort);
+            $targetLocation = (string) $user->ort;
         }
+
+        $normalizedTargetLocation = mb_strtolower(trim($targetLocation));
+        $matchingPlaceIds = Place::query()
+            ->whereRaw('LOWER(TRIM(pnname)) = ?', [$normalizedTargetLocation])
+            ->pluck('id')
+            ->map(function ($id) {
+                return (string) $id;
+            })
+            ->all();
+
+        $participantsQuery->where(function ($query) use ($normalizedTargetLocation, $matchingPlaceIds) {
+            $query->whereRaw('LOWER(TRIM(location)) = ?', [$normalizedTargetLocation]);
+
+            if (!empty($matchingPlaceIds)) {
+                $query->orWhereIn('location', $matchingPlaceIds);
+            }
+        });
 
         $participants = $participantsQuery->orderByDesc('created_at')->get();
     }

--- a/resources/views/layouts/admin_layout/admin_sidebar.blade.php
+++ b/resources/views/layouts/admin_layout/admin_sidebar.blade.php
@@ -315,7 +315,7 @@
           </a>
         </li>
         @endif
-        @if(auth()->user()->hasAnyRole(['Super_Admin','Verwaltung']))
+        @if(auth()->user()->hasAnyRole(['Super_Admin','Verwaltung','Teilnehmer_Info']))
         <li class="nav-item has-treeview">
           <a href="{{route ('participants.index')}}" class="nav-link">
             <i class="nav-icon fa-solid fa-users" style="color:#55917F;"></i>


### PR DESCRIPTION
### Motivation

- Ensure participant queries match both human-readable location names and numeric `Place` ids that were previously stored in the `location` column, by normalizing and resolving place names. 
- Allow users with the `Teilnehmer_Info` role to access the Teilnehmer Liste from the admin sidebar.

### Description

- Import `App\\Place` and change `ParticipantTicketTableController::index` to derive a `targetLocation`, normalize it with `mb_strtolower(trim(...))`, and resolve matching `Place` ids via `Place::whereRaw('LOWER(TRIM(pnname)) = ?', [...])->pluck('id')`.
- Update the participants query to filter where the normalized `location` equals the normalized target or where `location` is one of the resolved `Place` ids, preserving the existing time window and ordering logic.
- Cast resolved `Place` ids to strings before applying `orWhereIn` so they correctly compare against the `location` column values.
- Add `Teilnehmer_Info` to the sidebar access check in `resources/views/layouts/admin_layout/admin_sidebar.blade.php` so that users with that role see the Teilnehmer Liste link.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5a05c8848329b61b9001d5f8098d)