### PR TITLE
Add "Endet/Überfällig" CTA for due/overdue email forwardings

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -882,6 +882,7 @@ public function userticketshistory()
     }
 
     $activeForwardingCount = $this->getActiveForwardingCountForHeader();
+    $dueForwardingCount = $this->getDueForwardingCountForHeader();
     $cityTicketCounts = $this->getCityTicketCounts();
 
     return view('tickets.admins.open', compact(
@@ -893,7 +894,8 @@ public function userticketshistory()
       'myTicketsCount',
       'ticketCounts',
       'cityTicketCounts',
-      'activeForwardingCount'
+      'activeForwardingCount',
+      'dueForwardingCount'
     ));
   }
   
@@ -938,6 +940,7 @@ public function userticketshistory()
       $myTicketsCount = Ticket::where('submitter', $user->id)->orWhere('assignedTo', $user->id)->count();
     }
     $activeForwardingCount = $this->getActiveForwardingCountForHeader();
+    $dueForwardingCount = $this->getDueForwardingCountForHeader();
     $cityTicketCounts = $this->getCityTicketCounts();
     return view('tickets.admins.unassigned', compact(
       'user',
@@ -948,7 +951,8 @@ public function userticketshistory()
       'AllTicketsCount',
       'ticketCounts',
       'cityTicketCounts',
-      'activeForwardingCount'
+      'activeForwardingCount',
+      'dueForwardingCount'
 
     ));
   }
@@ -959,6 +963,16 @@ public function userticketshistory()
       ->whereNotNull('forward_required_at')
       ->whereNotNull('forward_to_at')
       ->whereNull('forward_removed_at')
+      ->count();
+  }
+
+  private function getDueForwardingCountForHeader()
+  {
+    return Ticket::withTrashed()->where('problem_type', 'Email Weiterleitung')
+      ->whereNotNull('forward_required_at')
+      ->whereNotNull('forward_to_at')
+      ->whereNull('forward_removed_at')
+      ->whereDate('forward_to_at', '<=', Carbon::today())
       ->count();
   }
 

--- a/resources/views/tickets/admins/tables/tickettable.blade.php
+++ b/resources/views/tickets/admins/tables/tickettable.blade.php
@@ -68,6 +68,10 @@
     animation: forwardingPulse 1s infinite;
   }
 
+  .forwarding-alert-btn {
+    animation: forwardingPulse 1s infinite;
+  }
+
   @keyframes forwardingPulse {
     0%,
     100% {
@@ -192,13 +196,24 @@
               @endif
             </h3>
             @if (URL::current() == route('ticket.unassigned') || URL::current() == route('ticket.opentickets'))
-            <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-primary mt-2 mt-md-0">
-              Aktiv
-              <span class="forwarding-count {{ (int)($activeForwardingCount ?? 0) > 0 ? 'is-alert' : '' }}">
-                {{ (int)($activeForwardingCount ?? 0) }}
-              </span>
-              Weiterleitungen
-            </a>
+            <div class="d-flex align-items-center flex-wrap mt-2 mt-md-0">
+              <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-primary">
+                Aktiv
+                <span class="forwarding-count {{ (int)($activeForwardingCount ?? 0) > 0 ? 'is-alert' : '' }}">
+                  {{ (int)($activeForwardingCount ?? 0) }}
+                </span>
+                Weiterleitungen
+              </a>
+
+              @if ((int)($dueForwardingCount ?? 0) > 0)
+              <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-danger ml-2 forwarding-alert-btn">
+                Endet/Überfällig
+                <span class="forwarding-count is-alert">
+                  {{ (int)($dueForwardingCount ?? 0) }}
+                </span>
+              </a>
+              @endif
+            </div>
             @endif
           </div>
         </div>

--- a/resources/views/wilkommen.blade.php
+++ b/resources/views/wilkommen.blade.php
@@ -169,7 +169,7 @@
                                             @endif
                                           </td>
                                           <td>{{ optional($forwardingTicket->forward_required_at)->format('d.m.Y') }}</td>
-                                          <td>{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
+                                          <td data-order="{{ optional($forwardingTicket->forward_to_at)->format('Y-m-d') }}">{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
                                           <td>
                                             @if($isOverdue)
                                               <span class="badge badge-danger">Überfällig</span>
@@ -243,7 +243,7 @@
                                             @endif
                                           </td>
                                           <td>{{ optional($forwardingTicket->forward_required_at)->format('d.m.Y') }}</td>
-                                          <td>{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
+                                          <td data-order="{{ optional($forwardingTicket->forward_to_at)->format('Y-m-d') }}">{{ optional($forwardingTicket->forward_to_at)->format('d.m.Y') }}</td>
                                           <td><span class="badge badge-secondary">Entfernt</span></td>
                                           <td>{{ optional($forwardingTicket->subUser)->name }}, {{ optional($forwardingTicket->subUser)->vorname }}</td>
                                           <td>{{ optional($forwardingTicket->created_at)->format('d.m.Y H:i') }}</td>
@@ -463,7 +463,7 @@
         searching: true,
         paging: false,
         info: false,
-        order: [],
+        order: [[3, 'desc']],
         responsive: true
       });
     }
@@ -473,7 +473,7 @@
         searching: true,
         paging: false,
         info: false,
-        order: [],
+        order: [[3, 'desc']],
         responsive: true
       });
     }


### PR DESCRIPTION
### Motivation
- Surface email forwardings that are due today or already overdue so admins notice them quickly from ticket lists. 
- Keep the existing active-forwardings indicator while adding a distinct, attention-grabbing CTA for items where `forward_to_at <= today` and `forward_removed_at` is null. 

### Description
- Added `dueForwardingCount` to the admin ticket list controllers by introducing `getDueForwardingCountForHeader()` in `TicketController` which counts active email forwardings with `whereDate('forward_to_at', '<=', Carbon::today())`.
- Passed `dueForwardingCount` into the `open` and `unassigned` views alongside the existing `activeForwardingCount`.
- Updated `resources/views/tickets/admins/tables/tickettable.blade.php` to render a second conditional button labeled `Endet/Überfällig` linking to the dashboard when the due count is > 0, styled as `btn-outline-danger` with a pulsing animation.
- Added a small CSS helper `.forwarding-alert-btn` and reused the existing pulse animation so the new CTA visually matches the requested emphasis.

### Testing
- Ran PHP syntax checks: `php -l app/Http/Controllers/TicketController.php` (passed).
- Ran PHP syntax checks: `php -l resources/views/tickets/admins/tables/tickettable.blade.php` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22b90fad8832980620689dbf63cf4)