### PR TITLE
Add overdue terminations button to open/unassigned ticket headers

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -883,6 +883,7 @@ public function userticketshistory()
 
     $activeForwardingCount = $this->getActiveForwardingCountForHeader();
     $dueForwardingCount = $this->getDueForwardingCountForHeader();
+    $dueTerminationCount = $this->getDueTerminationCountForHeader();
     $cityTicketCounts = $this->getCityTicketCounts();
 
     return view('tickets.admins.open', compact(
@@ -895,7 +896,8 @@ public function userticketshistory()
       'ticketCounts',
       'cityTicketCounts',
       'activeForwardingCount',
-      'dueForwardingCount'
+      'dueForwardingCount',
+      'dueTerminationCount'
     ));
   }
   
@@ -941,6 +943,7 @@ public function userticketshistory()
     }
     $activeForwardingCount = $this->getActiveForwardingCountForHeader();
     $dueForwardingCount = $this->getDueForwardingCountForHeader();
+    $dueTerminationCount = $this->getDueTerminationCountForHeader();
     $cityTicketCounts = $this->getCityTicketCounts();
     return view('tickets.admins.unassigned', compact(
       'user',
@@ -952,7 +955,8 @@ public function userticketshistory()
       'ticketCounts',
       'cityTicketCounts',
       'activeForwardingCount',
-      'dueForwardingCount'
+      'dueForwardingCount',
+      'dueTerminationCount'
 
     ));
   }
@@ -973,6 +977,13 @@ public function userticketshistory()
       ->whereNotNull('forward_to_at')
       ->whereNull('forward_removed_at')
       ->whereDate('forward_to_at', '<=', Carbon::today())
+      ->count();
+  }
+
+  private function getDueTerminationCountForHeader()
+  {
+    return Termination::where('is_active', true)
+      ->whereDate('exit', '<=', Carbon::today())
       ->count();
   }
 

--- a/resources/views/tickets/admins/tables/tickettable.blade.php
+++ b/resources/views/tickets/admins/tables/tickettable.blade.php
@@ -213,6 +213,15 @@
                 </span>
               </a>
               @endif
+
+              @if ((int)($dueTerminationCount ?? 0) > 0)
+              <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline-danger ml-2 forwarding-alert-btn">
+                überfällige Kündigungen
+                <span class="forwarding-count is-alert">
+                  {{ (int)($dueTerminationCount ?? 0) }}
+                </span>
+              </a>
+              @endif
             </div>
             @endif
           </div>


### PR DESCRIPTION
### Motivation
- Provide the same header-level urgency indicator for overdue terminations on the open/unassigned tickets pages as already exists for email forwardings. 
- Only count terminations that are still active and whose `exit` date is today or earlier to match the requested business logic and show urgency.

### Description
- Added a new header metric `dueTerminationCount` to both `opentickets()` and `unassignedtickets()` and passed it into the ticket table view; changes in `app/Http/Controllers/TicketController.php`.
- Implemented `getDueTerminationCountForHeader()` which returns `Termination::where('is_active', true)->whereDate('exit', '<=', Carbon::today())->count()` in `TicketController`.
- Updated the ticket header partial `resources/views/tickets/admins/tables/tickettable.blade.php` to render a third button labeled `überfällige Kündigungen` that links to `route('dashboard')`, uses `btn-outline-danger`, and is only shown when the count is greater than zero.

### Testing
- Ran syntax checks with `php -l app/Http/Controllers/TicketController.php` and `php -l resources/views/tickets/admins/tables/tickettable.blade.php`, both returned no syntax errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72cf11a98832998ab47307ea0b7ca)