### PR TITLE
Add informational note to email forwarding form

### DIFF
--- a/resources/views/tickets/users/emailForward.blade.php
+++ b/resources/views/tickets/users/emailForward.blade.php
@@ -61,6 +61,7 @@
                               <div class="form-group mb-2 col-md-6">
                                 <label for="forward_to_at">Bis</label>
                                 <input type="text" class="form-control enddate" name="forward_to_at" required>
+                                <small class="form-text text-muted">Zur Aufhebung ist kein Ticket erforderlich, die Weiterleitung wird nach dem angegebenen Datum entfernt.</small>
                               </div>
                             </div>
                           </div>


### PR DESCRIPTION
The user requested an informational note to be added to the email forwarding ticket creation form. 
I have updated `resources/views/tickets/users/emailForward.blade.php` to include the following text under the "Bis" input field: 
"Zur Aufhebung ist kein Ticket erforderlich, die Weiterleitung wird nach dem angegebenen Datum entfernt."

The note is styled with `<small class="form-text text-muted">` to match standard Bootstrap/AdminLTE help text patterns used elsewhere in the project.

Verification was performed by reading the modified Blade template. Automated frontend and backend verification were skipped due to PHP version incompatibility (PHP 8.3 in environment vs Laravel 7 project requirements).

---
*PR created automatically by Jules for task [8836105986834529494](https://jules.google.com/task/8836105986834529494) started by @miqr-dev*