### PR TITLE
Add role-gated Handwerk ticket PDF export (ticket + comments)

### DIFF
--- a/app/Http/Controllers/HandwerkController.php
+++ b/app/Http/Controllers/HandwerkController.php
@@ -311,6 +311,24 @@ class HandwerkController extends Controller
   //   return view('handwerk.userhandwerks', compact('user', 'myhandwerk', 'handwerkdone', 'myhandwerkcount'));
   // }
 
+
+  public function exportTicketPdf($id)
+  {
+    abort_unless(auth()->user()->hasAnyRole(['Super_Admin', 'handwerk_admin']), 403);
+
+    $handwerk = Handwerk::with([
+      'room.location.place',
+      'subUser',
+      'comments.commenter',
+    ])->withTrashed()->findOrFail($id);
+
+    $comments = $handwerk->comments->sortBy('created_at')->values();
+
+    $pdf = PDF::loadView('handwerk.ticket_details', compact('handwerk', 'comments'));
+
+    return $pdf->stream('handwerk_ticket_' . $handwerk->id . '.pdf');
+  }
+
   public function show($id)
   {
     $user = Auth()->user();

--- a/resources/views/handwerk/show.blade.php
+++ b/resources/views/handwerk/show.blade.php
@@ -149,6 +149,14 @@
                         <input type="text" class="form-control" name="tel_number" value="{{$handwerk->tel_number}}"
                           readonly>
                       </div>
+                      @if(auth()->user()->hasAnyRole(['Super_Admin', 'handwerk_admin']))
+                      <div class="form-group col-md-12">
+                        <a href="{{ route('handwerk.ticket.pdf', $handwerk->id) }}" target="_blank" rel="noopener"
+                          class="btn btn-danger col-md-12">
+                          Ticket + Kommentare als PDF
+                        </a>
+                      </div>
+                      @endif
                     </div>
                   </div> <!-- Closing div for card-body -->
                 </div> <!-- Closing div for card -->

--- a/resources/views/handwerk/ticket_details.blade.php
+++ b/resources/views/handwerk/ticket_details.blade.php
@@ -32,6 +32,19 @@
             display: inline-block;
             width: 150px;
         }
+        .comment {
+            border-top: 1px solid #eee;
+            padding-top: 8px;
+            margin-top: 8px;
+        }
+        .comment-meta {
+            color: #555;
+            font-size: 11px;
+            margin-bottom: 4px;
+        }
+        .reply {
+            margin-left: 24px;
+        }
     </style>
 </head>
 <body>
@@ -84,6 +97,27 @@
             
             @if($handwerk->admin_notes)
                 <p><strong>Beschreibung:</strong> {!! nl2br(e($handwerk->admin_notes)) !!}</p>
+            @endif
+
+
+            @if(isset($comments) && $comments->count())
+                <p><strong>Kommentare:</strong></p>
+                @foreach($comments->where('child_id', null)->merge($comments->where('child_id', '')) as $comment)
+                    <div class="comment">
+                        <div class="comment-meta">
+                            {{ $comment->commenter->username ?? $comment->guest_name ?? 'Unbekannt' }} · {{ $comment->created_at->format('d.m.Y H:i') }}
+                        </div>
+                        <div>{!! $comment->comment !!}</div>
+                    </div>
+                    @foreach($comments->where('child_id', $comment->getKey()) as $reply)
+                        <div class="comment reply">
+                            <div class="comment-meta">
+                                {{ $reply->commenter->username ?? $reply->guest_name ?? 'Unbekannt' }} · {{ $reply->created_at->format('d.m.Y H:i') }}
+                            </div>
+                            <div>{!! $reply->comment !!}</div>
+                        </div>
+                    @endforeach
+                @endforeach
             @endif
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,7 @@ Route::get('handwerk/{city}/open-tickets-pdf', 'HandwerkController@openTicketsPD
 
 Route::get('handwerk', 'HandwerkController@index')->name('handwerk_index');  // index
 Route::get('/handwerk/{myHandwerkTicket}', 'HandwerkController@show')->name('handwerk_show');  // show
+Route::get('/handwerk/{myHandwerkTicket}/pdf', 'HandwerkController@exportTicketPdf')->name('handwerk.ticket.pdf');
 
 Route::get('einrichtungsgegenstände', 'Handwerkcontroller@einrichtungsgegenstände')->name('einrichtungsgegenstände'); //
 Route::get('elektro', 'Handwerkcontroller@elektro')->name('elektro');


### PR DESCRIPTION
### Motivation
- Provide a quick way for Handwerk admins to open a single ticket (with all comments and replies) as a PDF using the same full-ticket layout and have it open in a new browser tab.

### Description
- Added a new route `GET /handwerk/{myHandwerkTicket}/pdf` named `handwerk.ticket.pdf` to expose per-ticket PDF export.
- Implemented `HandwerkController::exportTicketPdf($id)` which aborts unless the user has `hasAnyRole(['Super_Admin', 'handwerk_admin'])`, eager-loads the ticket relations and comments (`comments.commenter`), and streams the generated PDF using `PDF::loadView('handwerk.ticket_details', ...)`.
- Inserted a role-gated button under the Telefon field in `resources/views/handwerk/show.blade.php` that links to the new route and opens the PDF in a new tab via `target="_blank"`.
- Extended `resources/views/handwerk/ticket_details.blade.php` to render comments and replies (using the standard comments relation) and added minimal styles so comments render cleanly in the PDF while preserving the existing ticket design.

### Testing
- Ran PHP syntax checks which passed for all modified files: `php -l app/Http/Controllers/HandwerkController.php`, `php -l routes/web.php`, `php -l resources/views/handwerk/show.blade.php`, and `php -l resources/views/handwerk/ticket_details.blade.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b172a14ec8329a7d607675458e79f)